### PR TITLE
Allow text to be updated by props

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,12 @@ var FloatLabelTextField = React.createClass({
     };
   },
 
+  componentWillReceiveProps: function(newProps) {
+    if (newProps.hasOwnProperty('value') && newProps.value !== this.state.text) {
+      this.setState({ text: newProps.value })
+    }
+  },
+
   withBorder: function() {
     if (!this.props.noBorder) {
       return styles.withBorder;


### PR DESCRIPTION
When the text input's value relies on a `prop`, and that prop get's updated in the parent component, the text input will not display the new value.

This PR listens for prop updates that contain a new value that is different than the current value of the text input and then set's the state with the updated prop value.
